### PR TITLE
fix footer quick-links

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -40,10 +40,11 @@ const Footer = () => {
       content: (
         <ul className="space-y-2 sm:space-y-3 text-[9px] xs:text-[10px] sm:text-xs md:text-sm text-left">
           {[
-            { href: "/about", text: "About Us" },
-            { href: "/resources", text: "Projects" },
+            { href: "#about", text: "About Us" },
+            { href: "/projects", text: "Projects" },
             { href: "https://mail.google.com/mail/?view=cm&fs=1&to=callofcode07@gmail.com", text: "Contact" },
-            { href: "/privacy", text: "Privacy Policy" },
+            // TODO: add `/privacy` route to display Privacy Policy
+            // { href: "/privacy", text: "Privacy Policy" },  
           ].map((link) => (
             <li key={link.href}>
               <Link


### PR DESCRIPTION
Fixed the following links on the quick links section of the footer
1. `About Us`
2. `Projects`

/privacy must be implemented to display the Privacy Policy. For now I have removed that link.

Resolves Issue #59 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "About Us" link in the footer to use an anchor link.
  * Changed the "Projects" link to point to the correct URL.
  * Removed the "Privacy Policy" link from the footer until the route is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->