### PR TITLE
add conditional rendering of github and linkedin links

### DIFF
--- a/components/Members-Text.tsx
+++ b/components/Members-Text.tsx
@@ -111,7 +111,7 @@ export default function MembersPage() {
     const fetchMembers = async () => {
       try {
         const res = await fetch("/api/members", {
-          signal: abortController.signal
+          signal: abortController.signal,
         });
         if (!res.ok) {
           setError(`Error ${res.status}: ${res.statusText}`);
@@ -140,8 +140,8 @@ export default function MembersPage() {
         const format = (m: Member): DisplayMember => ({
           name: m.name,
           imageSrc: m.profilePhoto ?? "/fallback.jpg",
-          githubLink: m.github ?? "#",
-          linkedinLink: m.linkedin ?? "#",
+          githubLink: m.github ?? "",
+          linkedinLink: m.linkedin ?? "",
         });
 
         const foundersList = approved
@@ -160,7 +160,7 @@ export default function MembersPage() {
         setSuperSeniors(superSeniorsList);
         setPresentMembers(presentList);
       } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
+        if (err instanceof Error && err.name === "AbortError") {
           return;
         }
         console.error("Failed to fetch members", err);
@@ -175,8 +175,6 @@ export default function MembersPage() {
     };
   }, []);
 
-
-  
   const tabs = [
     {
       title: "Present Members",
@@ -194,8 +192,6 @@ export default function MembersPage() {
       content: <MemberGrid members={founders} isFounder={true} />,
     },
   ];
-
-
 
   if (error) {
     return (

--- a/components/ui/members-card.tsx
+++ b/components/ui/members-card.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Github, Linkedin } from 'lucide-react';
+import React from "react";
+import { Github, Linkedin } from "lucide-react";
 
 interface MembersCardProps {
   name: string;
@@ -35,23 +35,27 @@ export default function MembersCard({
           </h3>
 
           <div className="flex justify-center space-x-4">
-            <a
-              href={githubLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
-            >
-              <Github size={18} className="text-black dark:text-white" />
-            </a>
-
-            <a
-              href={linkedinLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
-            >
-              <Linkedin size={18} className="text-black dark:text-white" />
-            </a>
+            {/* conditionally render links only if they exist */}
+            {githubLink && (
+              <a
+                href={githubLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
+              >
+                <Github size={18} className="text-black dark:text-white" />
+              </a>
+            )}
+            {linkedinLink && (
+              <a
+                href={linkedinLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
+              >
+                <Linkedin size={18} className="text-black dark:text-white" />
+              </a>
+            )}
           </div>
         </div>
       </div>
@@ -67,23 +71,27 @@ export default function MembersCard({
           {name}
         </h3>
         <div className="flex space-x-4">
-          <a
-            href={githubLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
-          >
-            <Github size={18} className="text-black dark:text-white" />
-          </a>
+          {githubLink && (
+            <a
+              href={githubLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
+            >
+              <Github size={18} className="text-black dark:text-white" />
+            </a>
+          )}
 
-          <a
-            href={linkedinLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
-          >
-            <Linkedin size={18} className="text-black dark:text-white" />
-          </a>
+          {linkedinLink && (
+            <a
+              href={linkedinLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-full bg-gray-100 dark:bg-gray-900 hover:bg-gray-200 dark:hover:bg-gray-800 transition-colors duration-200"
+            >
+              <Linkedin size={18} className="text-black dark:text-white" />
+            </a>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
 <img width="1596" height="888" alt="image" src="https://github.com/user-attachments/assets/3f9a32a0-9120-4f66-bb12-98a4c3b3289e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Member cards now hide GitHub and LinkedIn icons when no link is provided, preventing empty or dead links in both desktop and mobile views.
  - Default member social links are now empty by default, ensuring icons appear only when valid links exist.

- Style
  - Minor consistency and formatting updates with no user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->