### PR TITLE
Add fallback placeholder image for MembersCard when profile photo is null

### DIFF
--- a/components/ui/members-card.tsx
+++ b/components/ui/members-card.tsx
@@ -14,28 +14,27 @@ export default function MembersCard({
   githubLink,
   linkedinLink,
 }: MembersCardProps) {
+  const finalImage = imageSrc || "/fallback.jpg";
+
   return (
     <div className="w-full max-w-[200px] sm:max-w-[320px] mx-auto">
       {/* Desktop Card */}
       <div className="hidden sm:block group relative overflow-hidden rounded-2xl bg-white dark:bg-black shadow-md hover:shadow-[0_0_30px_5px_rgba(128,128,128,0.4)] transition-all duration-300 hover:-translate-y-1 border border-pink-500 dark:border-purple-500">
-        {/* Image */}
         <div className="aspect-square overflow-hidden">
           <img
-            src={imageSrc}
+            src={finalImage}
             alt={`Profile picture of ${name}`}
             className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
             loading="lazy"
           />
         </div>
 
-        {/* Name + Socials */}
         <div className="p-4">
           <h3 className="font-semibold text-lg text-center text-black dark:text-white mb-3 break-words">
             {name}
           </h3>
 
           <div className="flex justify-center space-x-4">
-            {/* conditionally render links only if they exist */}
             {githubLink && (
               <a
                 href={githubLink}
@@ -60,10 +59,10 @@ export default function MembersCard({
         </div>
       </div>
 
-      {/* Mobile Version */}
+      {/* Mobile Card */}
       <div className="block sm:hidden flex flex-col items-center gap-3 py-4">
         <img
-          src={imageSrc}
+          src={finalImage}
           alt={`Profile picture of ${name}`}
           className="w-28 h-28 rounded-full object-cover shadow-md border-4 border-pink-500 dark:border-purple-500"
         />

--- a/package-lock.json
+++ b/package-lock.json
@@ -4577,8 +4577,28 @@
       }
     },
     "node_modules/call-of-code": {
-      "resolved": "",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:",
+      "dependencies": {
+        "@heroicons/react": "^2.2.0",
+        "@radix-ui/react-slot": "^1.1.0",
+        "@tabler/icons-react": "^3.19.0",
+        "call-of-code": "file:",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "framer-motion": "^11.18.2",
+        "lucide-react": "^0.453.0",
+        "mini-svg-data-uri": "^1.4.4",
+        "next": "14.2.13",
+        "next-themes": "^0.3.0",
+        "pixel-retroui": "^2.1.0",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-icon-cloud": "^4.1.4",
+        "react-icons": "^5.4.0",
+        "tailwind-merge": "^2.6.0",
+        "tailwindcss-animate": "^1.0.7"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",


### PR DESCRIPTION
Summary: 
This PR adds a default fallback image for all member profile photos when the profile photo is missing or null.

 Changes
 Added `/public/fallback.jpg`
 Updated `MembersCard` to use `imageSrc || "/fallback.jpg"`
 Ensures clean UI for members without profile images

 Issue Fixed
Fixes #84



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Members cards now display a fallback image when the primary image source is unavailable, preventing broken image displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->